### PR TITLE
Fix PHP Notices when manually adding tickets

### DIFF
--- a/camptix-invoices.php
+++ b/camptix-invoices.php
@@ -141,7 +141,7 @@ function ctx_invoice_metabox_editable( $args ) {
 		)
 	);
 
-	if ( ! is_array( $order['items'] ) ) {
+	if ( empty( $order['items'] ) || ! is_array( $order['items'] ) ) {
 		$order['items'] = array();
 	}//end if
 	foreach ( $order['items'] as $k => $item ) {
@@ -180,13 +180,13 @@ function ctx_invoice_metabox_editable( $args ) {
 		</table>',
 		array(
 			esc_html__( 'Total amount', 'invoices-camptix' ),
-			esc_attr( $order['total'] ),
+			esc_attr( empty( $order['total'] ) ? '0' : $order['total'] ),
 			esc_html__( 'Customer', 'invoices-camptix' ),
-			esc_attr( $metas['name'] ),
+			esc_attr( empty( $metas['name'] ) ? '' : $metas['name'] ),
 			esc_html__( 'Contact email', 'invoices-camptix' ),
-			esc_attr( $metas['email'] ),
+			esc_attr( empty( $metas['email'] ) ? '' : $metas['email'] ),
 			esc_html__( 'Customer Address', 'invoices-camptix' ),
-			esc_textarea( $metas['address'] ),
+			esc_textarea( empty( $metas['address'] ) ? '' : $metas['address'] ),
 		)
 	);
 }


### PR DESCRIPTION
When manually adding a ticket, several PHP Notices are thrown due to direct access of array elements (on `false`).

This PR fixes this by respecting potentially empty/non-existing values. Another way to go about this would be to provide default arrays in L119 and L122, respectively. I found this the better/safer option, though.